### PR TITLE
fix: De-definitionlist header fields

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -309,56 +309,41 @@ This document intends to define the `Sec-CH-Width`, `Sec-CH-Viewport-Width`, and
 `Sec-CH-Width` Header Field {#iana-width}
 --------------------------
 
-Header field name:
-: Sec-CH-Width
+Header field name: Sec-CH-Width
 
-Applicable protocol:
-: http
+Applicable protocol: http
 
-Status:
-: standard
+Status: standard
 
-Author/Change controller:
-: IETF
+Author/Change controller: IETF
 
-Specification document:
-: this specification ([[#sec-ch-width]])
+Specification document: this specification ([[#sec-ch-width]])
 
 `Sec-CH-Viewport-Width` Header Field {#iana-viewport-width}
 --------------------------
 
-Header field name:
-: Sec-CH-Viewport-Width
+Header field name: Sec-CH-Viewport-Width
 
-Applicable protocol:
-: http
+Applicable protocol: http
 
-Status:
-: standard
+Status: standard
 
-Author/Change controller:
-: IETF
+Author/Change controller: IETF
 
-Specification document:
-: this specification ([[#sec-ch-viewport-width]])
+Specification document: this specification ([[#sec-ch-viewport-width]])
 
 `Sec-CH-DPR` Header Field {#iana-dpr}
 --------------------------
 
-Header field name:
-: Sec-CH-DPR
+Header field name: Sec-CH-DPR
 
-Applicable protocol:
-: http
+Applicable protocol: http
 
-Status:
-: standard
+Status: standard
 
-Author/Change controller:
-: IETF
+Author/Change controller: IETF
 
-Specification document:
-: this specification ([[#sec-ch-dpr]])
+Specification document: this specification ([[#sec-ch-dpr]])
 
 <pre class="anchors">
 urlPrefix: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure; spec: I-D.ietf-httpbis-header-structure


### PR DESCRIPTION
Bikeshed generates out the leading `:` as stub defintion lists with DTs which get flagged by HTML validation.
I didn't include a Bikeshed regneration of the HTML with this since the diff, since it made a very large diff