### PR TITLE
Don't send Sec-CH-Width when we're using a fallback `sizes`.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -87,6 +87,10 @@ The <code><dfn http-header export>Sec-CH-Width</dfn></code> request header field
 
 For [=fetches=] triggered by <{img}> elements, its value SHOULD be calculated by multiplying the <a href="https://html.spec.whatwg.org/multipage/images.html#source-set">source set</a>'s current <a href="https://html.spec.whatwg.org/multipage/images.html#source-size-2">source size</a> by the {{Window}}'s current {{Window/devicePixelRatio}}.
 
+It MUST NOT be sent when the user-agent is using a fallback <a href="https://html.spec.whatwg.org/multipage/images.html#source-size-2">source size</a>. Which is to say, if an <{img}>'s current <a href="https://html.spec.whatwg.org/multipage/images.html#source-size-2">source size</a> is `100vw` because any of the conditions in step 5 of <a href="https://html.spec.whatwg.org/multipage/images.html#parsing-a-sizes-attribute">parse a sizes attribute</a> returned true, <code><a http-header>Sec-CH-Width</a></code> MUST NOT be sent.
+
+Note: We should probably specify how user-agents track this state? I guess by setting a property like <em>fallback sizes used</em> (or whatever) on <{img}>.
+
 Note: the <a href="https://html.spec.whatwg.org/multipage/images.html#source-size-2">source size</a> may be zero. Servers should plan to receive requests for images to fit zero-width layout containers, and respond as best they can; for instance, with images clamped to some minimum (greater-than-zero) width.
 
 <div class="example">


### PR DESCRIPTION
Fixes #19 
